### PR TITLE
Add catalog audit logging to 1.27.7

### DIFF
--- a/plugins/catalog-backend/package.json
+++ b/plugins/catalog-backend/package.json
@@ -69,6 +69,7 @@
     "@backstage/plugin-permission-node": "workspace:^",
     "@backstage/plugin-search-backend-module-catalog": "workspace:^",
     "@backstage/types": "workspace:^",
+    "@janus-idp/backstage-plugin-audit-log-node": "^1.1.0",
     "@opentelemetry/api": "^1.3.0",
     "@types/express": "^4.17.6",
     "codeowners-utils": "^1.0.2",

--- a/plugins/catalog-backend/src/service/createRouter.test.ts
+++ b/plugins/catalog-backend/src/service/createRouter.test.ts
@@ -1345,10 +1345,7 @@ describe('createRouter readonly disabled', () => {
         entities: [],
       });
 
-      const response = await request(app)
-        .post('/locations')
-
-        .send(spec);
+      const response = await request(app).post('/locations').send(spec);
 
       expect(locationService.createLocation).toHaveBeenCalledTimes(1);
       expect(locationService.createLocation).toHaveBeenCalledWith(spec, false, {
@@ -1380,16 +1377,10 @@ describe('createRouter readonly disabled', () => {
         stage: 'completion',
         response: {
           status: 201,
-          body: expect.objectContaining({
-            location: { id: 'a', ...spec },
-          }),
         },
         meta: {
           isDryRun: false,
-          output: {
-            location: { id: 'a', ...spec },
-            entities: [],
-          },
+          location: { id: 'a', ...spec },
         },
       };
       expect(loggerSpy).toHaveBeenCalledTimes(2);
@@ -1418,7 +1409,6 @@ describe('createRouter readonly disabled', () => {
 
       const response = await request(app)
         .post('/locations?dryRun=true')
-
         .send(spec);
 
       expect(locationService.createLocation).toHaveBeenCalledTimes(1);
@@ -1452,16 +1442,10 @@ describe('createRouter readonly disabled', () => {
         stage: 'completion',
         response: {
           status: 201,
-          body: expect.objectContaining({
-            location: { id: 'a', ...spec },
-          }),
         },
         meta: {
           isDryRun: true,
-          output: {
-            location: { id: 'a', ...spec },
-            entities: [],
-          },
+          location: { id: 'a', ...spec },
         },
       };
       expect(loggerSpy).toHaveBeenCalledTimes(2);
@@ -2098,10 +2082,7 @@ describe('createRouter readonly enabled', () => {
         target: 'c',
       };
 
-      const response = await request(app)
-        .post('/locations')
-
-        .send(spec);
+      const response = await request(app).post('/locations').send(spec);
 
       expect(locationService.createLocation).not.toHaveBeenCalled();
       expect(response.status).toEqual(403);
@@ -2194,16 +2175,10 @@ describe('createRouter readonly enabled', () => {
         stage: 'completion',
         response: {
           status: 201,
-          body: expect.objectContaining({
-            location: { id: 'a', ...spec },
-          }),
         },
         meta: {
           isDryRun: true,
-          output: {
-            location: { id: 'a', ...spec },
-            entities: [],
-          },
+          location: { id: 'a', ...spec },
         },
       };
       expect(loggerSpy).toHaveBeenCalledTimes(2);

--- a/plugins/catalog-backend/src/service/createRouter.test.ts
+++ b/plugins/catalog-backend/src/service/createRouter.test.ts
@@ -44,11 +44,14 @@ import { Server } from 'http';
 import { mockCredentials, mockServices } from '@backstage/backend-test-utils';
 import { LocationAnalyzer } from '@backstage/plugin-catalog-node';
 
+const localhostNames = ['localhost', '127.0.0.1', '::1', '::ffff:127.0.0.1'];
+const localhostIps = ['127.0.0.1', '::1', '::ffff:127.0.0.1'];
+
 const commonAuditLogMeta = {
   actor: {
-    ip: '::ffff:127.0.0.1',
+    ip: expect.stringMatching(new RegExp(localhostIps.join('|'))),
     actorId: 'user:default/mock',
-    hostname: '127.0.0.1',
+    hostname: expect.stringMatching(new RegExp(localhostNames.join('|'))),
   },
   request: {
     body: {},

--- a/plugins/catalog-backend/src/service/createRouter.test.ts
+++ b/plugins/catalog-backend/src/service/createRouter.test.ts
@@ -1017,7 +1017,19 @@ describe('createRouter readonly disabled', () => {
   describe('DELETE /entities/by-uid/:uid', () => {
     it('can remove', async () => {
       entitiesCatalog.removeEntityByUid.mockResolvedValue(undefined);
-
+      entitiesCatalog.entities.mockResolvedValue({
+        entities: [
+          {
+            apiVersion: 'v1',
+            kind: 'k',
+            metadata: {
+              name: 'n',
+              namespace: 'ns',
+            },
+          },
+        ],
+        pageInfo: { hasNextPage: false },
+      });
       const response = await request(app).delete('/entities/by-uid/apa');
       expect(entitiesCatalog.removeEntityByUid).toHaveBeenCalledTimes(1);
       expect(entitiesCatalog.removeEntityByUid).toHaveBeenCalledWith('apa', {
@@ -1037,6 +1049,7 @@ describe('createRouter readonly disabled', () => {
         },
         meta: {
           uid: 'apa',
+          entityRef: 'k:ns/n',
         },
         stage: 'initiation',
       };
@@ -1062,7 +1075,10 @@ describe('createRouter readonly disabled', () => {
       entitiesCatalog.removeEntityByUid.mockRejectedValue(
         new NotFoundError('nope'),
       );
-
+      entitiesCatalog.entities.mockResolvedValue({
+        entities: [],
+        pageInfo: { hasNextPage: false },
+      });
       const response = await request(app).delete('/entities/by-uid/apa');
       expect(entitiesCatalog.removeEntityByUid).toHaveBeenCalledTimes(1);
       expect(entitiesCatalog.removeEntityByUid).toHaveBeenCalledWith('apa', {
@@ -1465,7 +1481,11 @@ describe('createRouter readonly disabled', () => {
   describe('DELETE /locations', () => {
     it('deletes the location', async () => {
       locationService.deleteLocation.mockResolvedValueOnce(undefined);
-
+      locationService.getLocation.mockResolvedValueOnce({
+        id: 'joo',
+        target: 'test',
+        type: 'url',
+      });
       const response = await request(app).delete('/locations/foo');
       expect(locationService.deleteLocation).toHaveBeenCalledTimes(1);
       expect(locationService.deleteLocation).toHaveBeenCalledWith('foo', {
@@ -1494,7 +1514,11 @@ describe('createRouter readonly disabled', () => {
         ...auditLogInitMeta,
         stage: 'completion',
         meta: {
-          id: 'foo',
+          location: {
+            id: 'joo',
+            target: 'test',
+            type: 'url',
+          },
         },
         response: {
           status: 204,
@@ -1910,6 +1934,19 @@ describe('createRouter readonly enabled', () => {
   describe('DELETE /entities/by-uid/:uid', () => {
     // this delete is allowed as there is no other way to remove entities
     it('is allowed', async () => {
+      entitiesCatalog.entities.mockResolvedValue({
+        entities: [
+          {
+            apiVersion: 'v1',
+            kind: 'k',
+            metadata: {
+              name: 'n',
+              namespace: 'ns',
+            },
+          },
+        ],
+        pageInfo: { hasNextPage: false },
+      });
       const response = await request(app).delete('/entities/by-uid/apa');
       expect(entitiesCatalog.removeEntityByUid).toHaveBeenCalledTimes(1);
       expect(entitiesCatalog.removeEntityByUid).toHaveBeenCalledWith('apa', {
@@ -1929,6 +1966,7 @@ describe('createRouter readonly enabled', () => {
         },
         meta: {
           uid: 'apa',
+          entityRef: 'k:ns/n',
         },
         stage: 'initiation',
       };

--- a/plugins/catalog-backend/src/service/createRouter.test.ts
+++ b/plugins/catalog-backend/src/service/createRouter.test.ts
@@ -44,6 +44,29 @@ import { Server } from 'http';
 import { mockCredentials, mockServices } from '@backstage/backend-test-utils';
 import { LocationAnalyzer } from '@backstage/plugin-catalog-node';
 
+const commonAuditLogMeta = {
+  actor: {
+    ip: '::ffff:127.0.0.1',
+    actorId: 'user:default/mock',
+    hostname: '127.0.0.1',
+  },
+  request: {
+    body: {},
+    method: 'GET',
+    params: {},
+    query: {},
+  },
+  isAuditLog: true,
+  meta: {},
+  status: 'succeeded',
+};
+const commonAuditErrorMeta = {
+  ...commonAuditLogMeta,
+  status: 'failed',
+  stage: 'completion',
+  errors: [],
+};
+
 describe('createRouter readonly disabled', () => {
   let entitiesCatalog: jest.Mocked<EntitiesCatalog>;
   let locationService: jest.Mocked<LocationService>;
@@ -51,6 +74,9 @@ describe('createRouter readonly disabled', () => {
   let app: express.Express | Server;
   let refreshService: RefreshService;
   let locationAnalyzer: jest.Mocked<LocationAnalyzer>;
+  const logger = getVoidLogger();
+  let loggerSpy: jest.SpyInstance;
+  let loggerErrorSpy: jest.SpyInstance;
 
   beforeAll(async () => {
     entitiesCatalog = {
@@ -74,11 +100,12 @@ describe('createRouter readonly disabled', () => {
     };
     refreshService = { refresh: jest.fn() };
     orchestrator = { process: jest.fn() };
+
     const router = await createRouter({
       entitiesCatalog,
       locationService,
       orchestrator,
-      logger: getVoidLogger(),
+      logger,
       refreshService,
       config: new ConfigReader(undefined),
       permissionIntegrationRouter: express.Router(),
@@ -91,6 +118,8 @@ describe('createRouter readonly disabled', () => {
 
   beforeEach(() => {
     jest.resetAllMocks();
+    loggerSpy = jest.spyOn(logger, 'info');
+    loggerErrorSpy = jest.spyOn(logger, 'error');
   });
 
   describe('POST /refresh', () => {
@@ -104,21 +133,82 @@ describe('createRouter readonly disabled', () => {
         entityRef: 'Component/default:foo',
         credentials: mockCredentials.user(),
       });
+      const auditLogInitMeta = {
+        ...commonAuditLogMeta,
+        eventName: 'CatalogEntityRefresh',
+        request: {
+          ...commonAuditLogMeta.request,
+          body: { entityRef: 'Component/default:foo' },
+          url: '/refresh',
+          method: 'POST',
+        },
+        meta: {
+          entityRef: 'Component/default:foo',
+        },
+        stage: 'initiation',
+      };
+      const auditLogCompletionMeta = {
+        ...auditLogInitMeta,
+        stage: 'completion',
+        response: { status: 200 },
+      };
+      expect(loggerSpy).toHaveBeenCalledTimes(2);
+      expect(loggerSpy).toHaveBeenNthCalledWith(
+        1,
+        `Refresh attempt for Component/default:foo initiated by user:default/mock`,
+        auditLogInitMeta,
+      );
+      expect(loggerSpy).toHaveBeenNthCalledWith(
+        2,
+        `Refresh attempt for Component/default:foo triggered by user:default/mock`,
+        auditLogCompletionMeta,
+      );
     });
 
     it('should support passing the token in the request body for backwards compatibility', async () => {
+      const requestBody = {
+        entityRef: 'Component/default:foo',
+        authorizationToken: mockCredentials.user.token('user:default/other'),
+      };
       const response = await request(app)
         .post('/refresh')
         .set('Content-Type', 'application/json')
-        .send({
-          entityRef: 'Component/default:foo',
-          authorizationToken: mockCredentials.user.token('user:default/other'),
-        });
+        .send(requestBody);
       expect(response.status).toBe(200);
       expect(refreshService.refresh).toHaveBeenCalledWith({
         entityRef: 'Component/default:foo',
         credentials: mockCredentials.user('user:default/other'),
       });
+      const auditLogInitMeta = {
+        ...commonAuditLogMeta,
+        eventName: 'CatalogEntityRefresh',
+        request: {
+          ...commonAuditLogMeta.request,
+          body: requestBody,
+          url: '/refresh',
+          method: 'POST',
+        },
+        meta: {
+          entityRef: 'Component/default:foo',
+        },
+        stage: 'initiation',
+      };
+      const auditLogCompletionMeta = {
+        ...auditLogInitMeta,
+        stage: 'completion',
+        response: { status: 200 },
+      };
+      expect(loggerSpy).toHaveBeenCalledTimes(2);
+      expect(loggerSpy).toHaveBeenNthCalledWith(
+        1,
+        `Refresh attempt for Component/default:foo initiated by user:default/mock`,
+        auditLogInitMeta,
+      );
+      expect(loggerSpy).toHaveBeenNthCalledWith(
+        2,
+        `Refresh attempt for Component/default:foo triggered by user:default/mock`,
+        auditLogCompletionMeta,
+      );
     });
   });
 
@@ -137,6 +227,32 @@ describe('createRouter readonly disabled', () => {
 
       expect(response.status).toEqual(200);
       expect(response.body).toEqual(entities);
+      const auditLogInitMeta = {
+        ...commonAuditLogMeta,
+        eventName: 'CatalogEntityFetch',
+        request: {
+          ...commonAuditLogMeta.request,
+          url: '/entities',
+          method: 'GET',
+        },
+        stage: 'initiation',
+      };
+      const auditLogCompletionMeta = {
+        ...auditLogInitMeta,
+        stage: 'completion',
+        response: { status: 200 },
+      };
+      expect(loggerSpy).toHaveBeenCalledTimes(2);
+      expect(loggerSpy).toHaveBeenNthCalledWith(
+        1,
+        `Entity fetch attempt initiated by user:default/mock`,
+        auditLogInitMeta,
+      );
+      expect(loggerSpy).toHaveBeenNthCalledWith(
+        2,
+        `Entity fetch attempt by user:default/mock succeeded`,
+        auditLogCompletionMeta,
+      );
     });
 
     it('parses single and multiple request parameters and passes them down', async () => {
@@ -164,6 +280,35 @@ describe('createRouter readonly disabled', () => {
         },
         credentials: mockCredentials.user(),
       });
+      const auditLogInitMeta = {
+        ...commonAuditLogMeta,
+        eventName: 'CatalogEntityFetch',
+        request: {
+          ...commonAuditLogMeta.request,
+          url: '/entities?filter=a=1,a=2,b=3&filter=c=4',
+          method: 'GET',
+          query: {
+            filter: ['a=1,a=2,b=3', 'c=4'],
+          },
+        },
+        stage: 'initiation',
+      };
+      const auditLogCompletionMeta = {
+        ...auditLogInitMeta,
+        stage: 'completion',
+        response: { status: 200 },
+      };
+      expect(loggerSpy).toHaveBeenCalledTimes(2);
+      expect(loggerSpy).toHaveBeenNthCalledWith(
+        1,
+        `Entity fetch attempt initiated by user:default/mock`,
+        auditLogInitMeta,
+      );
+      expect(loggerSpy).toHaveBeenNthCalledWith(
+        2,
+        `Entity fetch attempt by user:default/mock succeeded`,
+        auditLogCompletionMeta,
+      );
     });
   });
 

--- a/plugins/catalog-backend/src/service/createRouter.ts
+++ b/plugins/catalog-backend/src/service/createRouter.ts
@@ -56,6 +56,8 @@ import {
 } from '@backstage/backend-plugin-api';
 import { LocationAnalyzer } from '@backstage/plugin-catalog-node';
 
+import { DefaultAuditLogger } from '@janus-idp/backstage-plugin-audit-log-node';
+
 /**
  * Options used by {@link createRouter}.
  *
@@ -103,6 +105,11 @@ export async function createRouter(
     httpAuth,
   } = options;
 
+  const auditLogger = new DefaultAuditLogger({
+    logger,
+    authService: auth,
+    httpAuthService: httpAuth,
+  });
   const readonlyEnabled =
     config.getOptionalBoolean('catalog.readonly') || false;
   if (readonlyEnabled) {
@@ -110,18 +117,65 @@ export async function createRouter(
   }
 
   if (refreshService) {
+    // TODO: Potentially find a way to track the ancestor that gets refreshed to refresh this entity (as well as the child of that ancestor?)
     router.post('/refresh', async (req, res) => {
       const { authorizationToken, ...restBody } = req.body;
+      const actorId = await auditLogger.getActorId(req);
+      try {
+        await auditLogger.auditLog({
+          eventName: 'CatalogEntityRefresh',
+          actorId,
+          status: 'succeeded',
+          stage: 'initiation',
+          metadata: {
+            entityRef: restBody.entityRef,
+          },
+          request: req,
+          message: `Refresh attempt for ${restBody.entityRef} initiated by ${actorId}`,
+        });
 
-      const credentials = authorizationToken
-        ? await auth.authenticate(authorizationToken)
-        : await httpAuth.credentials(req);
+        const credentials = authorizationToken
+          ? await auth.authenticate(authorizationToken)
+          : await httpAuth.credentials(req);
 
-      await refreshService.refresh({
-        ...restBody,
-        credentials,
-      });
-      res.status(200).end();
+        await refreshService.refresh({
+          ...restBody,
+          credentials,
+        });
+        res.status(200).end();
+        await auditLogger.auditLog({
+          eventName: 'CatalogEntityRefresh',
+          actorId,
+          status: 'succeeded',
+          stage: 'completion',
+          metadata: {
+            entityRef: restBody.entityRef,
+          },
+          request: req,
+          message: `Refresh for ${restBody.entityRef} triggered by ${actorId}`,
+        });
+      } catch (err) {
+        await auditLogger.auditLog({
+          eventName: 'CatalogEntityRefresh',
+          actorId,
+          status: 'failed',
+          stage: 'completion',
+          level: 'error',
+          errors: [
+            {
+              name: err.name,
+              message: err.message,
+              stack: err.stack,
+            },
+          ],
+          metadata: {
+            entityRef: restBody.entityRef,
+          },
+          request: req,
+          message: `Refresh attempt for ${restBody.entityRef} by ${actorId} failed`,
+        });
+        throw err;
+      }
     });
   }
 
@@ -132,101 +186,440 @@ export async function createRouter(
   if (entitiesCatalog) {
     router
       .get('/entities', async (req, res) => {
-        const { entities, pageInfo } = await entitiesCatalog.entities({
-          filter: parseEntityFilterParams(req.query),
-          fields: parseEntityTransformParams(req.query),
-          order: parseEntityOrderParams(req.query),
-          pagination: parseEntityPaginationParams(req.query),
-          credentials: await httpAuth.credentials(req),
-        });
-
-        // Add a Link header to the next page
-        if (pageInfo.hasNextPage) {
-          const url = new URL(`http://ignored${req.url}`);
-          url.searchParams.delete('offset');
-          url.searchParams.set('after', pageInfo.endCursor);
-          res.setHeader('link', `<${url.pathname}${url.search}>; rel="next"`);
-        }
-
-        // TODO(freben): encode the pageInfo in the response
-        res.json(entities);
-      })
-      .get('/entities/by-query', async (req, res) => {
-        const { items, pageInfo, totalItems } =
-          await entitiesCatalog.queryEntities({
-            limit: req.query.limit,
-            ...parseQueryEntitiesParams(req.query),
+        const actorId = await auditLogger.getActorId(
+          req as unknown as express.Request,
+        );
+        try {
+          await auditLogger.auditLog({
+            eventName: 'CatalogEntityFetch',
+            actorId,
+            status: 'succeeded',
+            stage: 'initiation',
+            request: req as unknown as express.Request,
+            message: `Entity fetch attempt initiated by ${actorId}`,
+          });
+          const { entities, pageInfo } = await entitiesCatalog.entities({
+            filter: parseEntityFilterParams(req.query),
+            fields: parseEntityTransformParams(req.query),
+            order: parseEntityOrderParams(req.query),
+            pagination: parseEntityPaginationParams(req.query),
             credentials: await httpAuth.credentials(req),
           });
 
-        res.json({
-          items,
-          totalItems,
-          pageInfo: {
-            ...(pageInfo.nextCursor && {
-              nextCursor: encodeCursor(pageInfo.nextCursor),
-            }),
-            ...(pageInfo.prevCursor && {
-              prevCursor: encodeCursor(pageInfo.prevCursor),
-            }),
-          },
-        });
+          // Add a Link header to the next page
+          if (pageInfo.hasNextPage) {
+            const url = new URL(`http://ignored${req.url}`);
+            url.searchParams.delete('offset');
+            url.searchParams.set('after', pageInfo.endCursor);
+            res.setHeader('link', `<${url.pathname}${url.search}>; rel="next"`);
+          }
+
+          await auditLogger.auditLog({
+            eventName: 'CatalogEntityFetch',
+            actorId,
+            status: 'succeeded',
+            stage: 'completion',
+            request: req as unknown as express.Request,
+            // Let's not log out the entities since this can make the log very big due to it not being paged?
+            response: {
+              status: 200,
+            },
+            message: `Entity fetch attempt initiated by ${actorId}`,
+          });
+
+          // TODO(freben): encode the pageInfo in the response
+          res.json(entities);
+        } catch (err) {
+          await auditLogger.auditLog({
+            eventName: 'CatalogEntityFetch',
+            status: 'failed',
+            stage: 'completion',
+            level: 'error',
+            request: req as unknown as express.Request,
+            errors: [
+              {
+                name: err.name,
+                message: err.message,
+                stack: err.stack,
+              },
+            ],
+            message: `Entity fetch attempt initiated by ${actorId}`,
+          });
+          throw err;
+        }
+      })
+      .get('/entities/by-query', async (req, res) => {
+        const actorId = await auditLogger.getActorId(
+          req as unknown as express.Request,
+        );
+        try {
+          await auditLogger.auditLog({
+            eventName: 'QueriedCatalogEntityFetch',
+            actorId,
+            status: 'succeeded',
+            stage: 'initiation',
+            request: req as unknown as express.Request,
+            message: `Queried entity fetch attempt initiated by ${actorId}`,
+          });
+          const { items, pageInfo, totalItems } =
+            await entitiesCatalog.queryEntities({
+              limit: req.query.limit,
+              ...parseQueryEntitiesParams(req.query),
+              credentials: await httpAuth.credentials(req),
+            });
+
+          res.json({
+            items,
+            totalItems,
+            pageInfo: {
+              ...(pageInfo.nextCursor && {
+                nextCursor: encodeCursor(pageInfo.nextCursor),
+              }),
+              ...(pageInfo.prevCursor && {
+                prevCursor: encodeCursor(pageInfo.prevCursor),
+              }),
+            },
+          });
+          await auditLogger.auditLog({
+            eventName: 'QueriedCatalogEntityFetch',
+            actorId,
+            status: 'succeeded',
+            stage: 'completion',
+            request: req as unknown as express.Request,
+            metadata: {
+              totalEntities: totalItems,
+              pageInfo: {
+                ...(pageInfo.nextCursor && {
+                  nextCursor: encodeCursor(pageInfo.nextCursor),
+                }),
+                ...(pageInfo.prevCursor && {
+                  prevCursor: encodeCursor(pageInfo.prevCursor),
+                }),
+              },
+            },
+            // Let's not log out the entities since this can make the log very big
+            response: {
+              status: 200,
+            },
+            message: `Queried entity fetch attempt by ${actorId} succeeded`,
+          });
+        } catch (err) {
+          await auditLogger.auditLog({
+            eventName: 'QueriedCatalogEntityFetch',
+            actorId,
+            status: 'failed',
+            stage: 'completion',
+            level: 'error',
+            request: req as unknown as express.Request,
+            errors: [
+              {
+                name: err.name,
+                message: err.message,
+                stack: err.stack,
+              },
+            ],
+            message: `Queried entity fetch attempt by ${actorId} failed`,
+          });
+          throw err;
+        }
       })
       .get('/entities/by-uid/:uid', async (req, res) => {
         const { uid } = req.params;
-        const { entities } = await entitiesCatalog.entities({
-          filter: basicEntityFilter({ 'metadata.uid': uid }),
-          credentials: await httpAuth.credentials(req),
-        });
-        if (!entities.length) {
-          throw new NotFoundError(`No entity with uid ${uid}`);
+        const actorId = await auditLogger.getActorId(req);
+        try {
+          await auditLogger.auditLog({
+            eventName: 'CatalogEntityFetch',
+            actorId,
+            status: 'succeeded',
+            stage: 'initiation',
+            request: req,
+            metadata: {
+              uid: uid,
+            },
+            message: `Fetch attempt for entity with uid ${uid} initiated by ${actorId}`,
+          });
+          const { entities } = await entitiesCatalog.entities({
+            filter: basicEntityFilter({ 'metadata.uid': uid }),
+            credentials: await httpAuth.credentials(req),
+          });
+          if (!entities.length) {
+            throw new NotFoundError(`No entity with uid ${uid}`);
+          }
+          res.status(200).json(entities[0]);
+          await auditLogger.auditLog({
+            eventName: 'CatalogEntityFetch',
+            actorId,
+            status: 'succeeded',
+            stage: 'completion',
+            request: req,
+            metadata: {
+              uid: uid,
+              entityRef: stringifyEntityRef(entities[0]),
+            },
+            response: {
+              status: 200,
+            },
+            message: `Fetch attempt for entity with uid ${uid} by ${actorId} succeeded`,
+          });
+        } catch (err) {
+          await auditLogger.auditLog({
+            eventName: 'CatalogEntityFetch',
+            actorId,
+            status: 'failed',
+            stage: 'completion',
+            level: 'error',
+            request: req,
+            metadata: {
+              uid: uid,
+            },
+            errors: [
+              {
+                name: err.name,
+                message: err.message,
+                stack: err.stack,
+              },
+            ],
+            message: `Fetch attempt for entity with uid ${uid} by ${actorId} failed`,
+          });
         }
-        res.status(200).json(entities[0]);
       })
       .delete('/entities/by-uid/:uid', async (req, res) => {
         const { uid } = req.params;
-        await entitiesCatalog.removeEntityByUid(uid, {
-          credentials: await httpAuth.credentials(req),
-        });
-        res.status(204).end();
+        const actorId = await auditLogger.getActorId(req);
+        try {
+          await auditLogger.auditLog({
+            eventName: 'CatalogEntityDeletion',
+            actorId,
+            status: 'succeeded',
+            stage: 'initiation',
+            request: req,
+            metadata: {
+              uid: uid,
+            },
+            message: `Deletion attempt for entity with uid ${uid} initiated by ${actorId}`,
+          });
+          await entitiesCatalog.removeEntityByUid(uid, {
+            credentials: await httpAuth.credentials(req),
+          });
+          await auditLogger.auditLog({
+            eventName: 'CatalogEntityDeletion',
+            actorId,
+            status: 'succeeded',
+            stage: 'initiation',
+            request: req,
+            metadata: {
+              uid: uid,
+            },
+            response: {
+              status: 204,
+            },
+            message: `Deletion attempt for entity with uid ${uid} by ${actorId} succeeded`,
+          });
+          res.status(204).end();
+        } catch (err) {
+          await auditLogger.auditLog({
+            eventName: 'CatalogEntityDeletion',
+            actorId,
+            status: 'failed',
+            stage: 'completion',
+            level: 'error',
+            request: req,
+            errors: [
+              {
+                name: err.name,
+                message: err.message,
+                stack: err.stack,
+              },
+            ],
+            message: `Deletion attempt for entity with uid ${uid} by ${actorId} failed`,
+          });
+          throw err;
+        }
       })
       .get('/entities/by-name/:kind/:namespace/:name', async (req, res) => {
         const { kind, namespace, name } = req.params;
-        const { entities } = await entitiesCatalog.entities({
-          filter: basicEntityFilter({
-            kind: kind,
-            'metadata.namespace': namespace,
-            'metadata.name': name,
-          }),
-          credentials: await httpAuth.credentials(req),
-        });
-        if (!entities.length) {
-          throw new NotFoundError(
-            `No entity named '${name}' found, with kind '${kind}' in namespace '${namespace}'`,
-          );
+        const entityRef = stringifyEntityRef({ kind, namespace, name });
+        const actorId = await auditLogger.getActorId(req);
+        try {
+          await auditLogger.auditLog({
+            eventName: 'CatalogEntityFetch',
+            actorId,
+            status: 'succeeded',
+            stage: 'initiation',
+            request: req,
+            metadata: {
+              entityRef: entityRef,
+            },
+            message: `Fetch attempt for entity with entityRef ${entityRef} initiated by ${actorId}`,
+          });
+          const { entities } = await entitiesCatalog.entities({
+            filter: basicEntityFilter({
+              kind: kind,
+              'metadata.namespace': namespace,
+              'metadata.name': name,
+            }),
+            credentials: await httpAuth.credentials(req),
+          });
+          if (!entities.length) {
+            throw new NotFoundError(
+              `No entity named '${name}' found, with kind '${kind}' in namespace '${namespace}'`,
+            );
+          }
+          res.status(200).json(entities[0]);
+          await auditLogger.auditLog({
+            eventName: 'CatalogEntityFetch',
+            actorId,
+            status: 'succeeded',
+            stage: 'completion',
+            request: req,
+            metadata: {
+              entityRef: entityRef,
+            },
+            response: {
+              status: 200,
+            },
+            message: `Fetch attempt for entity with entityRef ${entityRef} by ${actorId} succeeded`,
+          });
+        } catch (err) {
+          await auditLogger.auditLog({
+            eventName: 'CatalogEntityFetch',
+            actorId,
+            status: 'failed',
+            stage: 'completion',
+            request: req,
+            level: 'error',
+            metadata: {
+              entityRef: entityRef,
+            },
+            errors: [
+              {
+                name: err.name,
+                message: err.message,
+                stack: err.stack,
+              },
+            ],
+            message: `Fetch attempt for entity with entityRef ${entityRef} by ${actorId} failed`,
+          });
+          throw err;
         }
-        res.status(200).json(entities[0]);
       })
       .get(
         '/entities/by-name/:kind/:namespace/:name/ancestry',
         async (req, res) => {
           const { kind, namespace, name } = req.params;
           const entityRef = stringifyEntityRef({ kind, namespace, name });
-          const response = await entitiesCatalog.entityAncestry(entityRef, {
-            credentials: await httpAuth.credentials(req),
-          });
-          res.status(200).json(response);
+          const actorId = await auditLogger.getActorId(req);
+          try {
+            await auditLogger.auditLog({
+              eventName: 'CatalogEntityAncestryFetch',
+              actorId,
+              status: 'succeeded',
+              stage: 'initiation',
+              request: req,
+              metadata: {
+                entityRef: entityRef,
+              },
+              message: `Fetch attempt for entity ancestor of entity ${entityRef} initiated by ${actorId}`,
+            });
+            const response = await entitiesCatalog.entityAncestry(entityRef, {
+              credentials: await httpAuth.credentials(req),
+            });
+            res.status(200).json(response);
+            await auditLogger.auditLog({
+              eventName: 'CatalogEntityAncestryFetch',
+              actorId,
+              status: 'succeeded',
+              stage: 'completion',
+              request: req,
+              metadata: {
+                rootEntityRef: response.rootEntityRef,
+                ancestry: response.items.map(ancestryLink => {
+                  return {
+                    entityRef: stringifyEntityRef(ancestryLink.entity),
+                    parentEntityRefs: ancestryLink.parentEntityRefs,
+                  };
+                }),
+              },
+              response: {
+                status: 200,
+              },
+              message: `Fetch attempt for entity ancestor of entity ${entityRef} by ${actorId} succeeded`,
+            });
+          } catch (err) {
+            await auditLogger.auditLog({
+              eventName: 'CatalogEntityAncestryFetch',
+              actorId,
+              status: 'failed',
+              stage: 'completion',
+              level: 'error',
+              request: req,
+              metadata: {
+                entityRef: entityRef,
+              },
+              errors: [
+                {
+                  name: err.name,
+                  message: err.message,
+                  stack: err.stack,
+                },
+              ],
+              message: `Fetch attempt for entity ancestor of entity ${entityRef} by ${actorId} failed`,
+            });
+            throw err;
+          }
         },
       )
       .post('/entities/by-refs', async (req, res) => {
-        const request = entitiesBatchRequest(req);
-        const response = await entitiesCatalog.entitiesBatch({
-          entityRefs: request.entityRefs,
-          filter: parseEntityFilterParams(req.query),
-          fields: parseEntityTransformParams(req.query, request.fields),
-          credentials: await httpAuth.credentials(req),
-        });
-        res.status(200).json(response);
+        const actorId = await auditLogger.getActorId(req);
+        try {
+          await auditLogger.auditLog({
+            eventName: 'CatalogEntityBatchFetch',
+            actorId,
+            status: 'succeeded',
+            stage: 'initiation',
+            request: req,
+            message: `Batch entity fetch attempt initiated by ${actorId}`,
+          });
+          const request = entitiesBatchRequest(req);
+          const response = await entitiesCatalog.entitiesBatch({
+            entityRefs: request.entityRefs,
+            filter: parseEntityFilterParams(req.query),
+            fields: parseEntityTransformParams(req.query, request.fields),
+            credentials: await httpAuth.credentials(req),
+          });
+          res.status(200).json(response);
+          await auditLogger.auditLog({
+            eventName: 'CatalogEntityBatchFetch',
+            actorId,
+            status: 'succeeded',
+            stage: 'completion',
+            request: req,
+            metadata: {
+              ...request,
+            },
+            response: {
+              status: 200,
+            },
+            message: `Batch entity fetch attempt by ${actorId} succeeded`,
+          });
+        } catch (err) {
+          await auditLogger.auditLog({
+            eventName: 'CatalogEntityBatchFetch',
+            actorId,
+            status: 'failed',
+            stage: 'completion',
+            request: req,
+            errors: [
+              {
+                name: err.name,
+                message: err.message,
+                stack: err.stack,
+              },
+            ],
+            message: `Batch entity fetch attempt by ${actorId} failed`,
+          });
+          throw err;
+        }
       })
       .get('/entity-facets', async (req, res) => {
         const response = await entitiesCatalog.facets({
@@ -241,50 +634,297 @@ export async function createRouter(
   if (locationService) {
     router
       .post('/locations', async (req, res) => {
+        const credentials = await httpAuth.credentials(req);
+        const actorId = await auditLogger.getActorId(req);
         const location = await validateRequestBody(req, locationInput);
         const dryRun = yn(req.query.dryRun, { default: false });
 
-        // when in dryRun addLocation is effectively a read operation so we don't
-        // need to disallow readonly
-        if (!dryRun) {
-          disallowReadonlyMode(readonlyEnabled);
-        }
+        try {
+          await auditLogger.auditLog({
+            eventName: 'CatalogLocationCreation',
+            status: 'succeeded',
+            stage: 'initiation',
+            actorId,
+            metadata: {
+              location: location,
+              isDryRun: dryRun,
+            },
+            request: req,
+            message: `Creation attempt of location entity for ${location.target}  by ${actorId} initiated`,
+          });
 
-        const output = await locationService.createLocation(location, dryRun, {
-          credentials: await httpAuth.credentials(req),
-        });
-        res.status(201).json(output);
+          // when in dryRun addLocation is effectively a read operation so we don't
+          // need to disallow readonly
+          if (!dryRun) {
+            disallowReadonlyMode(readonlyEnabled);
+          }
+
+          const output = await locationService.createLocation(
+            location,
+            dryRun,
+            {
+              credentials,
+            },
+          );
+          await auditLogger.auditLog({
+            eventName: 'CatalogLocationCreation',
+            status: 'succeeded',
+            stage: 'completion',
+            actorId,
+            metadata: {
+              output: output,
+              isDryRun: dryRun,
+            },
+            request: req,
+            response: {
+              status: 201,
+              body: output,
+            },
+            message: `Creation of location for ${location.target} initiated by ${actorId} succeeded`,
+          });
+          res.status(201).json(output);
+        } catch (err) {
+          await auditLogger.auditLog({
+            eventName: 'CatalogLocationCreation',
+            status: 'failed',
+            stage: 'completion',
+            level: 'error',
+            actorId,
+            metadata: {
+              location: location,
+              isDryRun: dryRun,
+            },
+            errors: [
+              {
+                name: err.name,
+                message: err.message,
+                stack: err.stack,
+              },
+            ],
+            request: req,
+            message: `Creation of location for ${location.target} initiated by ${actorId} failed`,
+          });
+          throw err;
+        }
       })
       .get('/locations', async (req, res) => {
-        const locations = await locationService.listLocations({
-          credentials: await httpAuth.credentials(req),
-        });
-        res.status(200).json(locations.map(l => ({ data: l })));
+        const actorId = await auditLogger.getActorId(req);
+        try {
+          await auditLogger.auditLog({
+            eventName: 'CatalogLocationFetch',
+            status: 'succeeded',
+            stage: 'initiation',
+            actorId,
+            request: req,
+            message: `Fetch attempt of locations by ${actorId} initiated`,
+          });
+          const locations = await locationService.listLocations({
+            credentials: await httpAuth.credentials(req),
+          });
+          res.status(200).json(locations.map(l => ({ data: l })));
+          await auditLogger.auditLog({
+            eventName: 'CatalogLocationFetch',
+            status: 'succeeded',
+            stage: 'completion',
+            actorId,
+            request: req,
+            response: {
+              status: 200,
+            },
+            message: `Fetch attempt of locations by ${actorId} succeeded`,
+          });
+        } catch (err) {
+          await auditLogger.auditLog({
+            eventName: 'CatalogLocationFetch',
+            status: 'failed',
+            stage: 'completion',
+            actorId,
+            request: req,
+            errors: [
+              {
+                name: err.name,
+                message: err.message,
+                stack: err.stack,
+              },
+            ],
+            message: `Fetch attempt of locations by ${actorId} failed`,
+          });
+          throw err;
+        }
       })
 
       .get('/locations/:id', async (req, res) => {
         const { id } = req.params;
-        const output = await locationService.getLocation(id, {
-          credentials: await httpAuth.credentials(req),
-        });
-        res.status(200).json(output);
+        const actorId = await auditLogger.getActorId(req);
+        try {
+          await auditLogger.auditLog({
+            eventName: 'CatalogLocationFetch',
+            status: 'succeeded',
+            stage: 'initiation',
+            actorId,
+            metadata: {
+              id: id,
+            },
+            request: req,
+            message: `Fetch attempt of location with id: ${id} by ${actorId} initiated`,
+          });
+          const output = await locationService.getLocation(id, {
+            credentials: await httpAuth.credentials(req),
+          });
+          res.status(200).json(output);
+          await auditLogger.auditLog({
+            eventName: 'CatalogLocationFetch',
+            status: 'succeeded',
+            stage: 'completion',
+            actorId,
+            metadata: {
+              id: id,
+            },
+            response: {
+              status: 200,
+              body: output,
+            },
+            request: req,
+            message: `Fetch attempt of location with id: ${id} by ${actorId} succeeded`,
+          });
+        } catch (err) {
+          await auditLogger.auditLog({
+            eventName: 'CatalogLocationFetch',
+            status: 'failed',
+            stage: 'completion',
+            level: 'error',
+            actorId,
+            metadata: {
+              id: id,
+            },
+            errors: [
+              {
+                name: err.name,
+                message: err.message,
+                stack: err.stack,
+              },
+            ],
+            request: req,
+            message: `Fetch attempt of location with id: ${id} by ${actorId} failed`,
+          });
+        }
       })
       .delete('/locations/:id', async (req, res) => {
-        disallowReadonlyMode(readonlyEnabled);
-
+        const actorId = await auditLogger.getActorId(req);
         const { id } = req.params;
-        await locationService.deleteLocation(id, {
-          credentials: await httpAuth.credentials(req),
-        });
-        res.status(204).end();
+        try {
+          await auditLogger.auditLog({
+            eventName: 'CatalogLocationDeletion',
+            status: 'succeeded',
+            stage: 'initiation',
+            actorId,
+            metadata: {
+              id: id,
+            },
+            request: req,
+            message: `Deletion attempt of location with id: ${id} by ${actorId} initiated`,
+          });
+          disallowReadonlyMode(readonlyEnabled);
+
+          await locationService.deleteLocation(id, {
+            credentials: await httpAuth.credentials(req),
+          });
+          await auditLogger.auditLog({
+            eventName: 'CatalogLocationDeletion',
+            status: 'succeeded',
+            stage: 'completion',
+            actorId,
+            metadata: {
+              id: id,
+            },
+            response: {
+              status: 204,
+            },
+            request: req,
+            message: `Deletion attempt of location with id: ${id} by ${actorId} succeeded`,
+          });
+          res.status(204).end();
+        } catch (err) {
+          await auditLogger.auditLog({
+            eventName: 'CatalogLocationDeletion',
+            status: 'failed',
+            stage: 'completion',
+            level: 'error',
+            actorId,
+            metadata: {
+              id: id,
+            },
+            errors: [
+              {
+                name: err.name,
+                message: err.message,
+                stack: err.stack,
+              },
+            ],
+            request: req,
+            message: `Deletion attempt of location with id: ${id} by ${actorId} failed`,
+          });
+          throw err;
+        }
       })
       .get('/locations/by-entity/:kind/:namespace/:name', async (req, res) => {
         const { kind, namespace, name } = req.params;
-        const output = await locationService.getLocationByEntity(
-          { kind, namespace, name },
-          { credentials: await httpAuth.credentials(req) },
-        );
-        res.status(200).json(output);
+        const actorId = await auditLogger.getActorId(req);
+        const locationRef = `${kind}:${namespace}/${name}`;
+
+        try {
+          await auditLogger.auditLog({
+            eventName: 'CatalogLocationFetch',
+            status: 'succeeded',
+            stage: 'initiation',
+            actorId,
+            metadata: {
+              locationRef: locationRef,
+            },
+            request: req,
+            message: `Fetch attempt of location ${locationRef} by ${actorId} initiated`,
+          });
+
+          const output = await locationService.getLocationByEntity(
+            { kind, namespace, name },
+            { credentials: await httpAuth.credentials(req) },
+          );
+          res.status(200).json(output);
+          await auditLogger.auditLog({
+            eventName: 'CatalogLocationFetch',
+            status: 'succeeded',
+            stage: 'completion',
+            actorId,
+            metadata: {
+              locationRef: locationRef,
+            },
+            response: {
+              status: 200,
+              body: output,
+            },
+            request: req,
+            message: `Fetch attempt of location ${locationRef} by ${actorId} succeeded`,
+          });
+        } catch (err) {
+          await auditLogger.auditLog({
+            eventName: 'CatalogLocationFetch',
+            status: 'failed',
+            stage: 'completion',
+            actorId,
+            metadata: {
+              locationRef: locationRef,
+            },
+            errors: [
+              {
+                name: err.name,
+                message: err.message,
+                stack: err.stack,
+              },
+            ],
+            request: req,
+            message: `Fetch attempt of location ${locationRef} by ${actorId} failed`,
+          });
+        }
       });
   }
 

--- a/plugins/catalog-backend/src/service/createRouter.ts
+++ b/plugins/catalog-backend/src/service/createRouter.ts
@@ -677,8 +677,9 @@ export async function createRouter(
                 stack: err.stack,
               },
             ],
-            message: `Entity facet fetch attempt by ${actorId} succeeded`,
+            message: `Entity facet fetch attempt by ${actorId} failed`,
           });
+          throw err;
         }
       });
   }
@@ -860,6 +861,7 @@ export async function createRouter(
             request: req,
             message: `Fetch attempt of location with id: ${id} by ${actorId} failed`,
           });
+          throw err;
         }
       })
       .delete('/locations/:id', async (req, res) => {
@@ -981,6 +983,7 @@ export async function createRouter(
             request: req,
             message: `Fetch attempt for location ${locationRef} by ${actorId} failed`,
           });
+          throw err;
         }
       });
   }

--- a/plugins/catalog-backend/src/service/createRouter.ts
+++ b/plugins/catalog-backend/src/service/createRouter.ts
@@ -725,13 +725,12 @@ export async function createRouter(
             stage: 'completion',
             actorId,
             metadata: {
-              output: output,
+              location: output.location,
               isDryRun: dryRun,
             },
             request: req,
             response: {
               status: 201,
-              body: output,
             },
             message: `Creation of location entity for ${location.target} initiated by ${actorId} succeeded`,
           });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3502,7 +3502,7 @@ __metadata:
   languageName: unknown
   linkType: soft
 
-"@backstage/backend-plugin-api@workspace:^, @backstage/backend-plugin-api@workspace:packages/backend-plugin-api":
+"@backstage/backend-plugin-api@^0.6.17, @backstage/backend-plugin-api@workspace:^, @backstage/backend-plugin-api@workspace:packages/backend-plugin-api":
   version: 0.0.0-use.local
   resolution: "@backstage/backend-plugin-api@workspace:packages/backend-plugin-api"
   dependencies:
@@ -5286,6 +5286,7 @@ __metadata:
     "@backstage/plugin-search-backend-module-catalog": "workspace:^"
     "@backstage/repo-tools": "workspace:^"
     "@backstage/types": "workspace:^"
+    "@janus-idp/backstage-plugin-audit-log-node": ^1.1.0
     "@opentelemetry/api": ^1.3.0
     "@types/core-js": ^2.5.4
     "@types/express": ^4.17.6
@@ -9571,6 +9572,19 @@ __metadata:
   version: 0.1.2
   resolution: "@istanbuljs/schema@npm:0.1.2"
   checksum: 5ce9facf2f0e3f4a93e56853cdfd78456e22d2c210c677530046e9c634ddc323dd62423ac711cd3554b5be06052c87fb8e0c266aa9010726940654c357290e78
+  languageName: node
+  linkType: hard
+
+"@janus-idp/backstage-plugin-audit-log-node@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@janus-idp/backstage-plugin-audit-log-node@npm:1.1.0"
+  dependencies:
+    "@backstage/backend-plugin-api": ^0.6.17
+    "@backstage/errors": ^1.2.4
+    "@backstage/types": ^1.1.1
+    express: ^4.19.2
+    lodash: ^4.17.21
+  checksum: 0a1c6600768c16fdc807d677cb59370e2d5e72ccfc0aa64a30686997ae032bccb48bca7b9774a94be2ce4b260f881c0191a8380e63bc1f93ce774e88d848887f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->
Adding catalog audit logging to all endpoints. 

Currently some malformed requests are not captured by the audit logging due to it being handled by the openapi router's validator which occurs before the code in the `createRouter.ts` for the endpoint is executed.

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [x] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [x] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
