### PR TITLE
fix: gendocu public api error with yarn install

### DIFF
--- a/package.json
+++ b/package.json
@@ -109,7 +109,8 @@
     "csstype@npm:^3.0.2": "3.0.9",
     "csstype@npm:^3.1.2": "3.0.9",
     "csstype@npm:^3.1.3": "3.0.9",
-    "jest-haste-map@^29.7.0": "patch:jest-haste-map@npm%3A29.7.0#./.yarn/patches/jest-haste-map-npm-29.7.0-e3be419eff.patch"
+    "jest-haste-map@^29.7.0": "patch:jest-haste-map@npm%3A29.7.0#./.yarn/patches/jest-haste-map-npm-29.7.0-e3be419eff.patch",
+    "GendocuPublicApis": "npm:gendocu-public-apis@^1.0.0"
   },
   "dependencies": {
     "@backstage/errors": "workspace:^",

--- a/plugins/scaffolder-backend/src/scaffolder/actions/builtin/filesystem/delete.ts
+++ b/plugins/scaffolder-backend/src/scaffolder/actions/builtin/filesystem/delete.ts
@@ -16,10 +16,7 @@
 
 import { createTemplateAction } from '@backstage/plugin-scaffolder-node';
 import { InputError } from '@backstage/errors';
-import {
-  isChildPath,
-  resolveSafeChildPath,
-} from '@backstage/backend-plugin-api';
+import { resolveSafeChildPath } from '@backstage/backend-plugin-api';
 import fs from 'fs-extra';
 import globby from 'globby';
 import { examples } from './delete.examples';

--- a/plugins/scaffolder-node/src/actions/fetch.ts
+++ b/plugins/scaffolder-node/src/actions/fetch.ts
@@ -53,7 +53,9 @@ export async function fetchContents(options: {
   if (!fetchUrlIsAbsolute && baseUrl?.startsWith('file://')) {
     const basePath = baseUrl.slice('file://'.length);
     const srcDir = resolveSafeChildPath(path.dirname(basePath), fetchUrl);
-    await fs.copy(srcDir, outputPath, { filter: src => isChildPath(srcDir, src) });
+    await fs.copy(srcDir, outputPath, {
+      filter: src => isChildPath(srcDir, src),
+    });
   } else {
     const readUrl = getReadUrl(fetchUrl, baseUrl, integrations);
 

--- a/plugins/techdocs-node/CHANGELOG.md
+++ b/plugins/techdocs-node/CHANGELOG.md
@@ -1,7 +1,5 @@
 # @backstage/plugin-techdocs-node
 
-<<<<<<< HEAD
-=======
 ## 1.13.11
 
 ### Patch Changes
@@ -135,7 +133,6 @@
   - @backstage/integration@1.18.0-next.0
   - @backstage/backend-plugin-api@1.4.3-next.0
 
->>>>>>> 66e08b08f9 (chore: push release)
 ## 1.13.6
 
 ### Patch Changes

--- a/yarn.lock
+++ b/yarn.lock
@@ -23300,13 +23300,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"GendocuPublicApis@https://git.gendocu.com/gendocu/GendocuPublicApis.git#master":
-  version: 1.0.0
-  resolution: "GendocuPublicApis@https://git.gendocu.com/gendocu/GendocuPublicApis.git#commit=6e8d4c1d2342556a2e8e719f19385b266001ebae"
+"GendocuPublicApis@npm:gendocu-public-apis@^1.0.0":
+  version: 1.0.3
+  resolution: "gendocu-public-apis@npm:1.0.3"
   dependencies:
     "@improbable-eng/grpc-web": "npm:^0.14.0"
     google-protobuf: "npm:^3.15.8"
-  checksum: 10/a34386a6137d92f392121305fb899f63ba1631a1b60c80781f6e56e160c1d462a8ce4b3ee93cb67c73c079b53c6de57ba19f514f29dd11c9783cd0d8227c6968
+  checksum: 10/261a5cc97b599a7dfb492ac048e6bfce3f3bf64627f2b80ef195d5b6cefdbd4668d2b2ccd10676f01eb4f7862a5d19da567dd6ade9fc39a15268e81862308f7c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Pulls in [this upstream fix](https://github.com/backstage/backstage/pull/31289/changes) that resolves error when running `yarn install`

```
Fatal Error: unable to access 'https://git.gendocu.com/gendocu/GendocuPublicApis.git/': SSL certificate problem: certificate has expired
```

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#creating-changesets))
- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)
- [ ] All your commits have a `Signed-off-by` line in the message. ([more info](https://github.com/backstage/backstage/blob/master/CONTRIBUTING.md#developer-certificate-of-origin))
